### PR TITLE
Update command for torch+cpu only

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ for [Nemo Citrinet](https://docs.nvidia.com/nemo-framework/user-guide/latest/nem
 
 by default this plugin will install the full pytorch, to avoid dragging all the dependencies it is recommended you install the cpu only version of pytorch **before** installing the plugin
 
-`pip install torch==2.1.0+cpu  -f https://download.pytorch.org/whl/torch_stable.html`
+`pip install torch==2.6.0+cpu --index-url https://download.pytorch.org/whl/cpu`
 
 If you skip the step above then the full pytorch will be installed together with the plugin
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the recommended installation command to use PyTorch version 2.6.0 with an updated package index flag for better guidance on dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->